### PR TITLE
Bump org.owasp.dependencycheck from 9.0.8 to 9.0.10

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     application
     checkstyle
     id("com.github.spotbugs") version "6.1.2"
-    id("org.owasp.dependencycheck") version "9.0.8"
+    id("org.owasp.dependencycheck") version "9.0.10"
     pmd
     jacoco
     id("com.github.johnrengelman.shadow") version "8.1.1"


### PR DESCRIPTION
Bumps org.owasp.dependencycheck from 9.0.8 to 9.0.10.

---
updated-dependencies:
- dependency-name: org.owasp.dependencycheck dependency-type: direct:production update-type: version-update:semver-patch ...

## Changes proposed